### PR TITLE
Added list of books recommende by HSE

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@
 * [How to Become a Pure Mathematician](https://hbpms.blogspot.fr) **(eng)** — Интересный список, разбитый по предметам и уровням
 * [Chicago undergraduate mathematics bibliography](https://www.ocf.berkeley.edu/~abhishek/chicmath.htm) **(eng)** — Список из Калифорнийского университета в Беркли
 * [Литература - НМУ](https://docs.google.com/spreadsheets/d/1UWwIIAFwSwOQLK3m--LOaMOvHUivFDEz-JAnLa87i7Q) — Список рекомендаций из НМУ (листайте вкладки внизу)
+* [Рекомендации факультета математики НИУ ВШЭ](https://math.hse.ru/books)
 
 [↑ К содержанию](#Содержание)
 


### PR DESCRIPTION
Добавил список книг, которые рекомендует факультет математики НИУ ВШЭ.
В нём нет книг изданных самим НИУ ВШЭ и по соображениям объективности они не могут быть туда добавлены.