### PR TITLE
Remove custom domain configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ description: Список интересных книг по математик�
 
 google_analytics: UA-123345095-1
 
-url: https://rmbk.me/math_books
+url: https://uburuntu.github.io
+baseurl: /awesome-math-ru
 
 theme: jekyll-theme-cayman


### PR DESCRIPTION
## Summary
- remove CNAME usage by replacing custom domain URL with GitHub Pages defaults
- add `baseurl` so the site can be served from the repository path
- update `url` to point to `uburuntu.github.io`

## Testing
- `jekyll build` *(fails: command not found)*
- `python -m py_compile build_toc.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6a64f0fec8322bdffbc69c799ad2d