### PR TITLE
Add English quick reference

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,296 @@
+# Awesome Math
+
+English quick reference for the Russian awesome math list.
+
+[Russian version](README.md)
+
+## Contents
+
+- [Math Links](#math-links)
+  - [Resources](#resources)
+  - [Communities](#communities)
+  - [VK Groups](#vk-groups)
+  - [Telegram Channels](#telegram-channels)
+  - [Tools](#tools)
+  - [Popular Mathematics](#popular-mathematics)
+  - [Lists of Lists](#lists-of-lists)
+- [Mathematics for Beginners](#mathematics-for-beginners)
+  - [General Courses](#general-courses)
+  - [Algebra](#algebra)
+  - [Geometry](#geometry)
+  - [Trigonometry](#trigonometry)
+  - [Introductory Calculus](#introductory-calculus)
+- [Core Mathematics](#core-mathematics)
+  - [General Algebra](#general-algebra)
+  - [Linear Algebra](#linear-algebra)
+  - [Mathematical Analysis](#mathematical-analysis)
+  - [Differential Equations](#differential-equations)
+  - [Calculus of Variations](#calculus-of-variations)
+  - [Topology](#topology)
+  - [Logic](#logic)
+  - [Functional Analysis](#functional-analysis)
+- [Advanced Courses](#advanced-courses)
+  - [Mathematical Analysis](#advanced-mathematical-analysis)
+  - [Differential Equations](#advanced-differential-equations)
+  - [Category Theory](#category-theory)
+  - [Differential Geometry](#differential-geometry)
+  - [Algebraic Geometry](#algebraic-geometry)
+  - [Topology](#advanced-topology)
+- [Interesting Books](#interesting-books)
+- [History of Mathematics](#history-of-mathematics)
+- [Physics](#physics)
+  - [General Physics](#general-physics)
+  - [Theoretical Physics](#theoretical-physics)
+
+## Math Links
+
+### Resources
+
+- [Library Genesis](http://gen.lib.rus.ec) - Large online library with many books from this list.
+- [Kolxo3 Library](https://kolxo3.tk/) - Electronic library focused on science literature.
+- [Kvant Library](http://math.ru/lib/ser/bmkvant) - Books from the physics and mathematics editorial office of Nauka.
+- [Mathprofi.net](http://mathprofi.net) - Accessible higher mathematics through roughly the second university year.
+- [Math Stack Exchange](https://math.stackexchange.com) - Mathematics Q&A.
+- [MathOverflow](https://mathoverflow.net) - Research-level mathematics discussion.
+- [Freely available books](https://www.mccme.ru/free-books/) - Free books from MCCME.
+
+### Communities
+
+- [MSU Faculty of Mechanics and Mathematics Telegram chat](https://t.me/mechmath) - Discuss mathematics and suggestions for this list.
+- [Infernal Math Telegram chat](https://t.me/matheden) - Discussion and problem solving.
+- [dxdy.ru](http://dxdy.ru) - Scientific forum with a large mathematics community.
+- [/math/](https://2ch.hk/math) - Mathematics board.
+
+### VK Groups
+
+- [Matematura: MCCME books](https://vk.com/matematura)
+- [Hedgehog in Analysis](https://vk.com/mathhedgehog) - Interesting stories and help with problems.
+
+### Telegram Channels
+
+- [MCCME](https://t.me/cme_channel)
+- [Geometry Channel](https://t.me/geometrykanal)
+
+### Tools
+
+- [WolframAlpha](https://www.wolframalpha.com) - Problem solver for early university courses with many [math examples](https://www.wolframalpha.com/examples/Math.html).
+
+### Popular Mathematics
+
+- [Mathematical Etudes](https://etudes.ru)
+
+### Lists of Lists
+
+- [Math Textbook Recommendations](http://4chan-science.wikia.com/wiki/Math_Textbook_Recommendations)
+- [The MAA Basic Library List](https://www.maa.org/press/maa-reviews/the-basic-library-list-maas-recommendations-for-undergraduate-libraries)
+- [How to Become a Pure Mathematician](https://hbpms.blogspot.fr)
+- [Chicago undergraduate mathematics bibliography](https://www.ocf.berkeley.edu/~abhishek/chicmath.htm)
+- [NMU Literature](https://docs.google.com/spreadsheets/d/1UWwIIAFwSwOQLK3m--LOaMOvHUivFDEz-JAnLa87i7Q)
+- [HSE Faculty of Mathematics recommendations](https://math.hse.ru/books)
+
+## Mathematics for Beginners
+
+### General Courses
+
+- Courant and Robbins: *What Is Mathematics?*
+- M. I. Skanavi: *Elementary Mathematics*.
+- G. V. Dorofeev, M. K. Potapov, N. Kh. Rozov: mathematics for university entrance exams.
+- Oleg Ivanov: *Elementary Mathematics*.
+- Felix Klein: *Elementary Mathematics from a Higher Standpoint*.
+
+### Algebra
+
+- I. M. Gelfand, A. Shen: *Algebra*.
+- S. B. Gashkov: *Modern Elementary Algebra*.
+
+### Geometry
+
+- A. D. Alexandrov, A. L. Werner, V. I. Ryzhik: *Geometry* for grades 10-11.
+- Ya. P. Ponarin: *Elementary Geometry*, two volumes.
+- A. Yu. Kalinin, D. A. Tereshin: *Geometry*, grades 10-11.
+- D. Hilbert, S. Cohn-Vossen: *Geometry and the Imagination*.
+- A. P. Kiselev: *Geometry*.
+
+### Trigonometry
+
+- I. M. Gelfand, S. M. Lvovsky, A. L. Toom: *Trigonometry*.
+
+### Introductory Calculus
+
+- B. M. Davidovich: *Mathematical Analysis at School 57*.
+- L. S. Pontryagin: *Introduction to Higher Mathematics*, four books.
+- Ya. B. Zeldovich: *Higher Mathematics for Beginners and Its Applications to Physics*.
+
+## Core Mathematics
+
+### General Algebra
+
+- E. B. Vinberg: *A Course in Algebra*.
+- A. I. Kostrikin: *Introduction to Algebra*.
+- A. G. Kurosh: *Higher Algebra*, *Lectures on General Algebra*, *Group Theory*.
+- M. Atiyah, I. Macdonald: *Introduction to Commutative Algebra*.
+- A. L. Gorodentsev: *Algebra*.
+- I. R. Shafarevich: *Basic Notions of Algebra*.
+- E. Connell: *Elements of Abstract and Linear Algebra*.
+- P. Grillet: *Abstract Algebra*.
+- J. Rotman: *Advanced Modern Algebra*.
+- M. Artin: *Algebra*.
+- I. Herstein: *Topics in Algebra*.
+- P. Aluffi: *Algebra: Chapter 0*.
+
+### Linear Algebra
+
+- V. A. Ilyin, E. G. Poznyak: *Linear Algebra*.
+- D. V. Beklemishev: *A Course in Analytic Geometry and Linear Algebra*.
+- I. M. Gelfand: *Lectures on Linear Algebra*.
+- A. I. Maltsev: *Foundations of Linear Algebra*.
+- A. I. Kostrikin, Yu. I. Manin: *Linear Algebra and Geometry*.
+- S. Axler: *Linear Algebra Done Right*.
+- S. Treil: *Linear Algebra Done Wrong*.
+- G. Shilov: *Linear Algebra*.
+- K. Hoffman, R. Kunze: *Linear Algebra*.
+- P. Halmos: *Finite-Dimensional Vector Spaces*.
+- P. Peterson: *Linear Algebra*.
+- S. Roman: *Advanced Linear Algebra*.
+
+### Mathematical Analysis
+
+- T. Tao: *Real Analysis*.
+- C. Pugh: *Real Mathematical Analysis*.
+- W. Rudin: *Principles of Mathematical Analysis*.
+- V. A. Zorich: *Mathematical Analysis*.
+- R. Courant: *Differential and Integral Calculus*.
+- G. M. Fichtenholz: *A Course of Differential and Integral Calculus*.
+- S. M. Lvovsky: *Lectures on Mathematical Analysis*.
+- A. Ya. Khinchin: *Eight Lectures on Mathematical Analysis*.
+- Hardy, Littlewood, Polya: *Inequalities*.
+- N. N. Lebedev: *Special Functions and Their Applications*.
+- G. P. Tolstov: *Fourier Series*.
+
+### Differential Equations
+
+- V. I. Arnold: *Ordinary Differential Equations*.
+- I. G. Petrovsky: *Lectures on Ordinary Differential Equations*.
+- S. Farlow: *Partial Differential Equations for Scientists and Engineers*.
+
+### Calculus of Variations
+
+- I. M. Gelfand, S. V. Fomin: *Calculus of Variations*.
+
+### Topology
+
+- Yu. G. Borisovich, N. M. Bliznyakov, Ya. A. Izrailevich, T. N. Fomenko: *Introduction to Topology*.
+- V. Runde: *A Taste of Topology*.
+- J. Strom: *Modern Classical Homotopy Theory*.
+- T. Dieck: *Algebraic Topology*.
+- M. Crossley: *Essential Topology*.
+- Milnor and Wallace: *Differential Topology*.
+
+### Logic
+
+- S. C. Kleene: *Introduction to Metamathematics*, *Mathematical Logic*.
+- R. Stoll: *Sets, Logic, and Axiomatic Theories*.
+
+### Functional Analysis
+
+- A. A. Kirillov, A. D. Gvishiani: *Theorems and Problems in Functional Analysis*.
+- A. N. Kolmogorov, S. V. Fomin: *Elements of the Theory of Functions and Functional Analysis*.
+
+## Advanced Courses
+
+### Advanced Mathematical Analysis
+
+- A. I. Markushevich: *Theory of Functions of a Complex Variable*.
+- S. Ramanan: *Global Calculus*.
+- H. Amann, J. Escher: *Analysis*.
+- W. Fischer, I. Lieb: *A Course in Complex Analysis*.
+
+### Advanced Differential Equations
+
+- V. I. Arnold: advanced chapters on ordinary differential equations.
+
+### Category Theory
+
+- S. Mac Lane: *Categories for the Working Mathematician*.
+- R. Goldblatt: *Topoi: The Categorial Analysis of Logic*.
+
+### Differential Geometry
+
+- B. A. Dubrovin, S. P. Novikov, A. T. Fomenko: *Modern Geometry*.
+- M. Spivak: *A Comprehensive Introduction to Differential Geometry*.
+- K. Nomizu: *Foundations of Differential Geometry*.
+- J. Lee: *Manifolds and Differential Geometry*.
+- L. Nicolaescu: *Lectures on the Geometry of Manifolds*.
+- P. Michor: *Topics in Differential Geometry*.
+
+### Algebraic Geometry
+
+- I. R. Shafarevich: *Basic Algebraic Geometry*.
+- D. Mumford: *The Red Book of Varieties and Schemes*.
+- V. V. Ostrik, M. A. Tsfasman: algebraic geometry and number theory.
+- V. I. Arnold: *Real Algebraic Geometry*.
+- Yu. I. Manin: introduction to schemes and quantum groups.
+- R. Vakil: *Foundations of Algebraic Geometry*.
+- S. Bosch: *Algebraic Geometry and Commutative Algebra*.
+- U. Gortz, T. Wedhorn: *Algebraic Geometry*.
+- E. Harris: *The Geometry of Schemes*.
+
+### Advanced Topology
+
+- A. T. Fomenko, D. B. Fuks: *A Course in Homotopic Topology*.
+- A. Hatcher: *Algebraic Topology*.
+- J. Munkres: *Topology*.
+
+## Interesting Books
+
+- *Manga Guide to...* series.
+- N. A. Vavilov: *Concrete Group Theory I: Basic Concepts*.
+- P. S. Alexandrov: *Introduction to Group Theory*.
+- V. B. Alekseev: *Abel's Theorem in Problems and Solutions*.
+- N. Ya. Vilenkin: *Stories About Sets*.
+- M. M. Postnikov: *Fermat's Theorem: Introduction to Algebraic Number Theory*.
+- N. Steenrod: *The Topology of Fibre Bundles*.
+- A. Ya. Khinchin: *Three Pearls of Number Theory*.
+- O. Ya. Viro, O. A. Ivanov, N. Yu. Netsvetaev, V. M. Kharlamov: *Elementary Topology*.
+- Ya. P. Ponarin: *Algebra of Complex Numbers in Geometric Problems*.
+- A. A. Zaslavsky: *Geometric Transformations*.
+- V. Akopyan, A. A. Zaslavsky: geometric properties of conic sections.
+- V. I. Arnold: geometry of complex numbers, quaternions, and spins.
+- V. V. Prasolov: *Lobachevsky Geometry*.
+- D. V. Anosov: differential equations and visual methods.
+- V. V. Prasolov: *Intuitive Topology*.
+- D. V. Anosov: *From Newton to Kepler*.
+- G. Polya: *Mathematical Discovery*.
+- L. Carroll: *The Game of Logic*.
+- G. Polya: *How to Solve It*.
+- O. Ya. Viro, D. B. Fuks: introduction to homotopy theory, homology, and cohomology.
+- S. M. Gusein-Zade: *The Selective Bride*.
+- A. Ostermann, G. Wanner: *Geometry by Its History*.
+- T. Sundstrom: *Mathematical Reasoning: Writing and Proof*.
+- D. Dummit, R. Foote: *Abstract Algebra*.
+
+## History of Mathematics
+
+- M. Kline: *Mathematics: The Search for Truth*, *Mathematics: The Loss of Certainty*.
+- A. N. Kolmogorov: *Mathematics in Its Historical Development*.
+- I. K. Shtokalo: *History of Russian Mathematics*.
+- B. L. van der Waerden: *Science Awakening*.
+
+## Physics
+
+### General Physics
+
+- Introductory course: *The Feynman Lectures on Physics*; Landsberg's *Elementary Textbook of Physics*.
+- Advanced course: D. V. Sivukhin, Berkeley Physics Course, I. V. Savelyev, A. N. Matveev.
+- Electricity: I. E. Tamm, *Fundamentals of the Theory of Electricity*.
+
+### Theoretical Physics
+
+- General reference: Landau and Lifshitz, all volumes; George Joos and Ira Freeman, *Theoretical Physics*.
+- Classical mechanics: V. I. Arnold, *Mathematical Methods of Classical Mechanics*; Lanczos, *The Variational Principles of Mechanics*.
+- Electrodynamics: Landau and Lifshitz, volume 2; Jackson, *Classical Electrodynamics*.
+- Quantum mechanics: Dirac, *The Principles of Quantum Mechanics*; Feynman and Hibbs, *Quantum Mechanics and Path Integrals*; Landau and Lifshitz, volume 3.
+- Quantum field theory: Bogoliubov and Shirkov, Peskin and Schroeder, Weinberg.
+- Statistical physics: Fermi, *Thermodynamics*; Landau and Lifshitz, volume 5; Huang.
+- Solid-state physics: Ashcroft and Mermin; Kittel.
+- Hydrodynamics: L. G. Loitsyansky; Landau and Lifshitz, volume 6.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Математический список [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
+[English quick reference](README.en.md)
+
 # Содержание
 
 <!-- START_TOC -->


### PR DESCRIPTION
## Summary
- Add `README.en.md` as an English quick-reference version of the Russian math list.
- Link the English quick reference from the top of `README.md`.

## Verification
- `git diff --check`
- Inspected the README link diff and the new Markdown file locally.

## Manual QA
- Not run; Markdown-only change and no browser session was used.

## Risks / follow-ups
- This is a quick-reference translation, not a full editorial rewrite of every Russian note.

Fixes uburuntu/awesome-math-ru#6